### PR TITLE
Implemented EventBus and Listeners, Optimised Physics Engine, Improved Event Scheduler and ContactsHandler

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,6 +1,8 @@
 <component name="ProjectDictionaryState">
   <dictionary name="project">
     <words>
+      <w>cbegin</w>
+      <w>cend</w>
       <w>collidable</w>
       <w>immovables</w>
     </words>

--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -243,7 +243,6 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=IfStdIsConstantEvaluatedCanBeReplaced/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=StdIsConstantEvaluatedWillAlwaysEvaluateToConstant/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralTypo/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
-    <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/EnableClangFormatSupport/@EntryValue" value="false" type="bool" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/ALIGN_MULTILINE_ARGUMENT/@EntryValue" value="true" type="bool" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue" value="true" type="bool" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/ALIGN_MULTILINE_CALLS_CHAIN/@EntryValue" value="false" type="bool" />

--- a/include/entity/CollidableObject.h
+++ b/include/entity/CollidableObject.h
@@ -20,23 +20,38 @@ struct Collision;
 
 class CollidableObject : public PhysicsObject {
 public:
+    /**
+     * @brief Constructor for CollidableObject. Adds the object to the \code CollisionsHandler\endcode .
+     * Ensures the invariant that \code mass == 0\endcode if and only if type is \code CollidableObjectType::Immovable\endcode
+     * since zero mass is our convention for infinite mass. Asserts that mass is non-negative (so all movables have a positive mass).
+     * @param hitbox The hitbox of the CollidableObject
+     * @param sprite The sprite of the CollidableObject
+     * @param position The CollidableObject's initial position
+     * @param type The CollidableObject's movability
+     * @param mass The CollidableObject's mass
+     * @note With the current implementation, setting the type to immovable but passing in a non-zero mass does NOT
+     * crash the program. The mass simply gets overwritten to \code 0\endcode which might be confusing to the users of
+     * this class. However, setting the type to movable with a non-positive mass WOULD crash the program.
+     */
     CollidableObject(std::vector<sf::FloatRect> hitbox,
-        sf::Sprite sprite,
-        sf::Vector2f position = {0, 0},
-        CollidableObjectType type = CollidableObjectType::Movable,
-        float mass = 1);
+                     sf::Sprite sprite,
+                     sf::Vector2f position = {0, 0},
+                     CollidableObjectType type = CollidableObjectType::Movable,
+                     float mass = 1);
 
     const CollidableObjectType type;
     const float mass;
 
-    [[nodiscard]] float getInvMass() const {
-        return (mass == 0) ? 0 : (1.0f / mass);
-    }
+    /**
+     * Returns the mathematical inverse of the mass. Returns 0 if the object is immovable and has infinite mass.
+     * @return The inverse of the mass.
+     */
+    [[nodiscard]] float getInvMass() const;
 
     /**
- * @brief Gives the hitbox of the collider.
- * @return the hitbox of the collider.
- */
+     * @brief Gives the hitbox of the collider.
+     * @return the hitbox of the collider.
+     */
     [[nodiscard]] const Hitbox& getHitbox() const;
 
     /**
@@ -48,8 +63,6 @@ public:
     bool operator==(const CollidableObject& other) const;
 
     [[nodiscard]] Player* isPlayer();
-
-    
 
 private:
     Hitbox hitbox;

--- a/include/entity/CollidableObject.h
+++ b/include/entity/CollidableObject.h
@@ -64,6 +64,8 @@ public:
 
     [[nodiscard]] Player* isPlayer();
 
+    [[nodiscard]] const Player* isPlayer() const;
+
 private:
     Hitbox hitbox;
 };

--- a/include/entity/PhysicsObject.h
+++ b/include/entity/PhysicsObject.h
@@ -6,6 +6,7 @@
 #define PHYSICSOBJECT_H
 
 #include <iostream>
+#include <sstream>
 #include <vector>
 #include <SFML/Graphics/Sprite.hpp>
 
@@ -20,40 +21,117 @@ public:
 
     virtual ~PhysicsObject() = default;
 
-    const sf::Vector2f& getPositionRef() const { return position; }
+    /**
+     * @brief Maximum velocity of the gravity. This maximum is enforced by \code setGravityVelocity()\endcode and
+     * \code addGravityVelocity()\endcode.
+     */
+    static constexpr float MAX_FALL = 160;
+
+    /**
+     * @brief Returns a const reference to the position of the object. Useful for hitboxes.
+     * @return A const reference to the position of the object.
+     */
+    const sf::Vector2f& getPositionRef() const;
 
     // Public to make it easy to update just one of the components
+    /**
+     * @brief The intrinsic velocity of the object. It will always try to move with the intrinsic velocity.
+     */
     sf::Vector2f intrinsic_velocity = {0, 0};
 
+    /**
+     * @brief The velocity imparted by the surface the object is resting on (if any) or if the object is a player
+     * climbing another object.
+     */
     sf::Vector2f friction_velocity = {0, 0};
 
+    /**
+     * @brief The velocity imparted by impulse resolution.
+     */
     sf::Vector2f impulse_velocity = {0, 0};
 
+    /**
+     * @brief Sets the \code gravity_velocity\endcode to the given velocity and clamps it by \code MAX_FALL\endcode.
+     * @param velocity The new gravity velocity of the object.
+     */
+    void setGravityVelocity(sf::Vector2f velocity);
+
+    /**
+     * @brief Adds the given velocity to the object's \code gravity_velocity\endcode and clamps it by \code MAX_FALL\endcode.
+     * @param velocity The velocity to be added to the \code gravity_velocity\endcode.
+     */
+    void addGravityVelocity(sf::Vector2f velocity);
+
+    const sf::Vector2f& getGravityVelocity() const {
+        return gravity_velocity;
+    }
+
+    /**
+     * @brief Returns the total velocity of the PhysicsObject. This is the object's true overall velocity.
+     * @return The total velocity - sum of intrinsic, friction, impulse and gravitational velocities.
+     */
     [[nodiscard]] sf::Vector2f getTotalVelocity() const;
 
-    sf::Vector2f acceleration = {0, 0};
+    sf::Vector2f gravity_acceleration = {0, 0};
 
-    virtual void update(float deltaTime);
-
+    /**
+     * @return A const reference to the sprite of the object.
+     */
     [[nodiscard]] const sf::Sprite& getSprite() const;
 
+    /**
+     * @return The position of the object.
+     */
     [[nodiscard]] sf::Vector2f getPosition() const;
 
+    /**
+     * @brief Sets the position to the given position. Also updates the position of the \code sprite\endcode.
+     * @param position The new position of the object.
+     */
     void setPosition(sf::Vector2f position);
 
+    /**
+     * @brief Adds the given position to the object's current position. Also updates the position of the \code sprite\endcode.
+     * @param position The position to be added to the object's current position.
+     */
     void addPosition(sf::Vector2f position);
 
-    void printVelocity(const std::string& name) const {
-        std::cout << name << " intrinsic_velocity: x = " << intrinsic_velocity.x << " y = " << intrinsic_velocity.y << std::endl;
-        std::cout << name << " friction_velocity: x = " << friction_velocity.x << " y = " << friction_velocity.y << std::endl;
-        std::cout << name << " impulse_velocity: x = " << impulse_velocity.x << " y = " << impulse_velocity.y << std::endl;
-    }
+    /**
+     * @brief Prints the 3 velocities of the object with the given name in the format:
+     * \code
+     * name intrinsic_velocity: x = intrinsic_velocity.x, y = intrinsic_velocity.y
+     * ...
+     * \endcode
+     * @param name The name that would appear on the print function
+     */
+    void printVelocity(const std::string& name) const;
+
+    /**
+     * @brief Prints the 3 velocities of the object with the address of the object as its name.
+     */
+    void printVelocity() const;
 
 protected:
     sf::Sprite sprite;
 
 private:
+    /**
+     * @brief The PhysicsObject's position.
+     *
+     * @note It is private because \code PhysicsObject\endcode handles updating the position of the sprite. Whenever a
+     * position is updated, the sprite's position is updated as well using \code sprite.setPosition()\endcode.
+     */
     sf::Vector2f position;
+
+    /**
+     * @return The address of the object in the form of a string.
+     */
+    std::string getAddressAsString() const;
+
+    /**
+     * @brief Velocity due to gravity. Is capped at
+     */
+    sf::Vector2f gravity_velocity = {0, 0};
 };
 
 #endif //PHYSICSOBJECT_H

--- a/include/entity/player/PlayerInputHandler.h
+++ b/include/entity/player/PlayerInputHandler.h
@@ -21,22 +21,15 @@ class PlayerInputHandler {
 public:
     explicit PlayerInputHandler(Player& player): player(player) {}
 
-    void update(float deltaTime) {
-        if (&player.getState() == &PlayerStateGround::getInstance()) {
-            updateFromGroundState(deltaTime);
-            return;
-        }
-
-        if (&player.getState() == &PlayerStateAir::getInstance()) {
-            updateFromAirState(deltaTime);
-            return;
-        }
-
-        if (&player.getState() == &PlayerStateClimbing::getInstance()) {
-            updateFromClimbState(deltaTime);
-            return;
-        }
-    }
+    /**
+     * @brief Updates the player by deltaTime. Routes to the individual update functions for each of the three states.
+     *
+     * May change player's \code velocity\endcode, \code facing\endcode, and \code state\endcode via
+     * \code Player::try*\endcode methods.
+     *
+     * @param deltaTime The time to update the player by according to the input.
+     */
+    void update(float deltaTime);
 
 private:
     Player& player;
@@ -49,114 +42,28 @@ private:
         return InputManager::getInstance().wasPressedEarlierThan(key1, key2);
     }
 
-    void updateFromGroundState(float deltaTime) {
-        assert(&player.getState() == &PlayerStateGround::getInstance());
+    void updateFromGroundState(float deltaTime);
 
-        if (isPressed(dashKey)) {
-            if (bool success = player.tryDash(getDashDirection())) return;
-        }
+    void updateFromAirState(float deltaTime);
 
-        if (isPressed(climbKey)) {
-            if (bool success = player.tryClimb()) return;
-        }
+    void updateFromClimbState(float deltaTime);
 
-        if (isPressed(jumpKey)) {
-            if (bool success = player.tryJump()) return;
-        }
+    /**
+     * @brief Helper math function that makes a variable approach a value from either (positive or negative) direction
+     * by the specified step. Clamps \code to_make_approach\endcode to \code to_approach\endcode if over-stepping.
+     * @param to_make_approach The reference that will approach \code to_approach\endcode by \code step\endcode.
+     * @param to_approach The value \code to_make_approach\endcode will approach.
+     * @param step The rate at which \code to_make_approach\endcode will try to approach \code to_approach\endcode.
+     */
+    static void approach(float& to_make_approach, float to_approach, float step);
 
-        bool moveSomewhere = false;
-
-        if (isPressed(moveLeft) && (!isPressed(moveRight) || wasPressedEarlierThan(moveRight, moveLeft))) {
-            // Move left
-            moveSomewhere = true;
-            player.facing = Facing::Left;
-            approach(player.intrinsic_velocity.x, -Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime);
-        }
-
-        if (isPressed(moveRight) && (!isPressed(moveLeft) || wasPressedEarlierThan(moveLeft, moveRight))) {
-            // Move right
-            moveSomewhere = true;
-            player.facing = Facing::Right;
-            approach(player.intrinsic_velocity.x, Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime);
-        }
-
-        if (!moveSomewhere) {
-            approach(player.intrinsic_velocity.x, 0, Player::RUN_ACCELERATION * deltaTime);
-        }
-    }
-
-    void updateFromAirState(float deltaTime) {
-        assert(&player.getState() == &PlayerStateAir::getInstance());
-    }
-
-    void updateFromClimbState(float deltaTime) {
-        assert(&player.getState() == &PlayerStateClimbing::getInstance());
-    }
-
-    static void approach(float& to_make_approach, float to_approach, float step) {
-        assert(step >= 0);
-        if (to_make_approach > to_approach) {
-            to_make_approach = std::max(to_make_approach - step, to_approach);
-        } else if (to_make_approach < to_approach) {
-            to_make_approach = std::min(to_make_approach + step, to_approach);
-        }
-    }
-
-    DashDirection getDashDirection() {
-        std::optional<Key> verticalKey;
-        std::optional<Key> horizontalKey;
-
-        if (isPressed(moveUp)) {
-            if (isPressed(moveDown)) {
-                verticalKey = wasPressedEarlierThan(moveUp, moveDown) ? moveDown : moveUp;
-            } else {
-                verticalKey = moveUp;
-            }
-        } else {
-            if (isPressed(moveDown)) {
-                verticalKey = moveDown;
-            }
-        }
-
-        if (isPressed(moveLeft)) {
-            if (isPressed(moveRight)) {
-                horizontalKey = wasPressedEarlierThan(moveLeft, moveRight) ? moveRight : moveLeft;
-            } else {
-                horizontalKey = moveLeft;
-            }
-        } else {
-            if (isPressed(moveRight)) {
-                horizontalKey = moveRight;
-            }
-        }
-
-        DashDirection direction = Player::DEFAULT_DASH_DIRECTION;
-
-        if (verticalKey) {
-            if (horizontalKey) {
-                if (verticalKey == moveUp && horizontalKey == moveLeft) {
-                    direction = DashDirection::UP_LEFT;
-                }
-                if (verticalKey == moveUp && horizontalKey == moveRight) {
-                    direction = DashDirection::UP_RIGHT;
-                }
-                if (verticalKey == moveDown && horizontalKey == moveLeft) {
-                    direction = DashDirection::DOWN_LEFT;
-                }
-                if (verticalKey == moveDown && horizontalKey == moveRight) {
-                    direction = DashDirection::DOWN_RIGHT;
-                }
-            } else {
-                direction = verticalKey == moveUp ? DashDirection::UP : DashDirection::DOWN;
-            }
-        } else {
-            if (horizontalKey) {
-                direction = horizontalKey == moveLeft ? DashDirection::LEFT : DashDirection::RIGHT;
-            }
-        }
-
-        return direction;
-    }
+    /**
+     * Gets the dash direction according to the current input. Combines the latest pressed vertical key (if any) and
+     * the latest pressed horizontal key (if any) to get the dash direction. Defaults to
+     * \code Player::DEFAULT_DASH_DIRECTION\endcode no horizontal or vertical key is pressed.
+     * @return The dash direction according to the current input.
+     */
+    DashDirection getDashDirection();
 
     Key dashKey = Key::L;
     Key climbKey = Key::K;

--- a/include/entity/player/PlayerInputHandler.h
+++ b/include/entity/player/PlayerInputHandler.h
@@ -5,15 +5,11 @@
 #ifndef PLAYERINPUTHANDLER_H
 #define PLAYERINPUTHANDLER_H
 
-#include <ranges>
-
 #include "Player.h"
 #include "../../utility/InputManager.h"
 #include <SFML/Graphics.hpp>
 
 #include "DashDirection.h"
-#include "PlayerStateAir.h"
-#include "PlayerStateClimbing.h"
 
 using namespace sf::Keyboard;
 
@@ -31,6 +27,14 @@ public:
      */
     void update(float deltaTime);
 
+    /**
+     * Gets the dash direction according to the current input. Combines the latest pressed vertical key (if any) and
+     * the latest pressed horizontal key (if any) to get the dash direction. Defaults to
+     * \code Player::DEFAULT_DASH_DIRECTION\endcode no horizontal or vertical key is pressed.
+     * @return The dash direction according to the current input.
+     */
+    static DashDirection getDashDirection();
+
 private:
     Player& player;
 
@@ -42,11 +46,7 @@ private:
         return InputManager::getInstance().wasPressedEarlierThan(key1, key2);
     }
 
-    void updateFromGroundState(float deltaTime);
-
-    void updateFromAirState(float deltaTime);
-
-    void updateFromClimbState(float deltaTime);
+    void handleLeftRightMovement(float deltaTime);
 
     /**
      * @brief Helper math function that makes a variable approach a value from either (positive or negative) direction
@@ -57,22 +57,14 @@ private:
      */
     static void approach(float& to_make_approach, float to_approach, float step);
 
-    /**
-     * Gets the dash direction according to the current input. Combines the latest pressed vertical key (if any) and
-     * the latest pressed horizontal key (if any) to get the dash direction. Defaults to
-     * \code Player::DEFAULT_DASH_DIRECTION\endcode no horizontal or vertical key is pressed.
-     * @return The dash direction according to the current input.
-     */
-    DashDirection getDashDirection();
-
-    Key dashKey = Key::L;
-    Key climbKey = Key::K;
-    Key moveLeft = Key::A;
-    Key moveRight = Key::D;
-    Key moveDown = Key::S;
-    Key moveUp = Key::W;
-    Key crouchKey = Key::S;
-    Key jumpKey = Key::Space;
+    static constexpr Key dashKey = Key::L;
+    static constexpr Key climbKey = Key::K;
+    static constexpr Key moveLeft = Key::A;
+    static constexpr Key moveRight = Key::D;
+    static constexpr Key moveDown = Key::S;
+    static constexpr Key moveUp = Key::W;
+    static constexpr Key crouchKey = Key::S;
+    static constexpr Key jumpKey = Key::Space;
 };
 
 

--- a/include/events/Contact.h
+++ b/include/events/Contact.h
@@ -13,28 +13,32 @@ struct Contact {
     explicit Contact(Collision collision) :
     objectA(collision.objectA),
     objectB(collision.objectB),
-    collidingRectA(collision.getCollidingRectA()),
-    collidingRectB(collision.getCollidingRectA()) {
+    collidingRectAIndex(collision.collidingRectAIndex),
+    collidingRectBIndex(collision.collidingRectBIndex) {
         axis = (collision.axis == CollisionAxis::Down || collision.axis == CollisionAxis::Up) ? ContactAxis::Y : ContactAxis::X;
     }
 
 
     CollidableObject& objectA;
     CollidableObject& objectB;
-    sf::FloatRect collidingRectA;
-    sf::FloatRect collidingRectB;
+    std::size_t collidingRectAIndex;
+    std::size_t collidingRectBIndex;
     ContactAxis axis;
+
+    [[nodiscard]] sf::FloatRect getCollidingRectA() const;
+
+    [[nodiscard]] sf::FloatRect getCollidingRectB() const;
 
     bool operator==(const Contact& other) const;
 
     [[nodiscard]] float contactLength() const {
         if (axis == ContactAxis::Y) {
-            const float left = std::max(collidingRectA.position.x, collidingRectB.position.x);
-            const float right = std::min(collidingRectA.position.x + collidingRectA.size.x, collidingRectB.position.x + collidingRectB.size.x);
+            const float left = std::max(getCollidingRectA().position.x, getCollidingRectB().position.x);
+            const float right = std::min(getCollidingRectA().position.x + getCollidingRectA().size.x, getCollidingRectB().position.x + getCollidingRectB().size.x);
             return (right - left > 0) ? right - left : 0;
         } else {
-            const float top = std::max(collidingRectA.position.y, collidingRectB.position.y);
-            const float bottom = std::min(collidingRectA.position.y + collidingRectA.size.y, collidingRectB.position.y + collidingRectB.size.y);
+            const float top = std::max(getCollidingRectA().position.y, getCollidingRectB().position.y);
+            const float bottom = std::min(getCollidingRectA().position.y + getCollidingRectA().size.y, getCollidingRectB().position.y + getCollidingRectB().size.y);
             return (bottom - top > 0) ? bottom - top : 0;
         }
     }

--- a/include/events/Event.h
+++ b/include/events/Event.h
@@ -1,0 +1,41 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#ifndef EVENT_H
+#define EVENT_H
+#include <functional>
+#include <typeindex>
+
+#include "EventExecuteTime.h"
+
+class DummyEvent {};
+
+class Event {
+public:
+    template <typename T>
+    explicit Event(T event, EventExecuteTime execute_time);
+
+    const std::type_index type_index;
+    const EventExecuteTime execute_time;
+
+    template <typename EventType>
+    [[nodiscard]] const EventType* getIf() const;
+
+    template <typename EventType>
+    [[nodiscard]] bool is() const;
+
+private:
+    struct GeneralEventBase {
+        virtual ~GeneralEventBase() = default;
+    };
+    template<typename EventType>
+    struct GeneralEvent final : GeneralEventBase {
+        GeneralEvent(EventType data) : data(std::move(data)) {}
+        EventType data;
+    };
+
+    std::shared_ptr<const GeneralEventBase> meta_data;
+};
+
+#endif //EVENT_H

--- a/include/events/Event.h
+++ b/include/events/Event.h
@@ -14,16 +14,22 @@ class DummyEvent {};
 class Event {
 public:
     template <typename T>
-    explicit Event(T event, EventExecuteTime execute_time);
+    explicit Event(T event, EventExecuteTime execute_time) : type_index(typeid(event)), execute_time(execute_time), meta_data(std::make_shared<GeneralEvent<T>>(std::move(event))) {}
 
     const std::type_index type_index;
     const EventExecuteTime execute_time;
 
     template <typename EventType>
-    [[nodiscard]] const EventType* getIf() const;
+    [[nodiscard]] const EventType* getIf() const {
+        if (type_index != typeid(EventType)) return nullptr;
+        auto ptr = dynamic_cast<GeneralEvent<EventType>*>(&meta_data);
+        return ptr ? &ptr->data : nullptr;
+    }
 
     template <typename EventType>
-    [[nodiscard]] bool is() const;
+    [[nodiscard]] bool is() const {
+        return type_index == typeid(EventType);
+    }
 
 private:
     struct GeneralEventBase {

--- a/include/events/Event.h
+++ b/include/events/Event.h
@@ -22,8 +22,8 @@ public:
     template <typename EventType>
     [[nodiscard]] const EventType* getIf() const {
         if (type_index != typeid(EventType)) return nullptr;
-        auto ptr = dynamic_cast<GeneralEvent<EventType>*>(&meta_data);
-        return ptr ? &ptr->data : nullptr;
+        auto derived = std::dynamic_pointer_cast<const GeneralEvent<EventType>>(meta_data);
+        return derived ? &derived->data : nullptr;
     }
 
     template <typename EventType>

--- a/include/events/EventBus.h
+++ b/include/events/EventBus.h
@@ -1,0 +1,42 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#ifndef EVENTBUS_H
+#define EVENTBUS_H
+#include <queue>
+#include <set>
+#include <typeindex>
+#include <unordered_map>
+
+#include "Event.h"
+#include "Listener.h"
+#include "../../../../../../opt/homebrew/Cellar/sfml/3.0.1/include/SFML/Window/Event.hpp"
+#include "events/EventExecuteTime.h"
+
+class EventBus {
+public:
+    static EventBus& getInstance();
+
+    void emit(Event event);
+
+    template<typename T>
+    void emit(T event, EventExecuteTime execute_time) {
+        emit(Event{event, execute_time});
+    }
+
+    void executeNow(Event event) const;
+
+    void execute(EventExecuteTime time);
+
+    void registerListener(Listener listener);
+
+private:
+    std::unordered_map<EventExecuteTime, std::queue<Event>> events_by_execution;
+
+    std::unordered_map<std::type_index, std::multiset<Listener, ListenerComparator>> listeners;
+};
+
+
+
+#endif //EVENTBUS_H

--- a/include/events/EventBus.h
+++ b/include/events/EventBus.h
@@ -10,9 +10,11 @@
 #include <unordered_map>
 
 #include "Event.h"
-#include "Listener.h"
-#include "../../../../../../opt/homebrew/Cellar/sfml/3.0.1/include/SFML/Window/Event.hpp"
 #include "events/EventExecuteTime.h"
+
+class Listener;
+
+struct ListenerComparator;
 
 class EventBus {
 public:

--- a/include/events/EventExecuteTime.h
+++ b/include/events/EventExecuteTime.h
@@ -1,0 +1,18 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#ifndef EVENTEXECUTETIME_H
+#define EVENTEXECUTETIME_H
+
+
+
+enum class EventExecuteTime {
+    NOW,
+    PRE_PHYSICS,
+    POST_PHYSICS
+};
+
+
+
+#endif //EVENTEXECUTETIME_H

--- a/include/events/EventExecuteTime.h
+++ b/include/events/EventExecuteTime.h
@@ -9,6 +9,7 @@
 
 enum class EventExecuteTime {
     NOW,
+    PRE_INPUT,
     PRE_PHYSICS,
     POST_PHYSICS
 };

--- a/include/events/Listener.h
+++ b/include/events/Listener.h
@@ -1,0 +1,37 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#ifndef LISTENER_H
+#define LISTENER_H
+#include <functional>
+#include <typeindex>
+#include <utility>
+
+#include "Event.h"
+#include "ListenerPriority.h"
+
+class Listener {
+public:
+    template<typename T>
+    explicit Listener(std::function<void(const T&)> cb, ListenerPriority priority = ListenerPriority::NORMAL) :
+        priority(priority), type_index(typeid(T)), erased_cb([fn = std::move(cb)](const void* ev) {
+            fn(*static_cast<const T*>(ev));
+        }) {}
+
+    const ListenerPriority priority;
+    const std::type_index type_index;
+
+    void call(const void* ev) const;
+
+private:
+    std::function<void(const void*)> erased_cb;
+};
+
+struct ListenerComparator {
+    bool operator()(const Listener& listenerA, const Listener& listenerB) const {
+        return listenerA.priority < listenerB.priority;
+    }
+};
+
+#endif //LISTENER_H

--- a/include/events/ListenerPriority.h
+++ b/include/events/ListenerPriority.h
@@ -1,0 +1,24 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#ifndef EVENTPRIORITY_H
+#define EVENTPRIORITY_H
+
+
+/**
+ * Listeners are called in following order: \code LOWEST\endcode -> \code LOW\endcode -> \code NORMAL\endcode ->
+ * \code HIGH\endcode -> \code HIGHEST\endcode -> \code MONITOR\endcode.
+ */
+enum class ListenerPriority {
+    LOWEST,
+    LOW,
+    NORMAL,
+    HIGH,
+    HIGHEST,
+    MONITOR
+};
+
+
+
+#endif //EVENTPRIORITY_H

--- a/include/events/PlayerLeftGround.h
+++ b/include/events/PlayerLeftGround.h
@@ -1,0 +1,19 @@
+//
+// Created by Agamjeet Singh on 19/08/25.
+//
+
+#ifndef PLAYERLEFTGROUND_H
+#define PLAYERLEFTGROUND_H
+#include "entity/player/Player.h"
+
+
+struct PlayerLeftGround {
+    explicit PlayerLeftGround(const Player& player): player(player) {}
+
+    const Player& player;
+    // TODO - Implement which ground it was on, if needed
+};
+
+
+
+#endif //PLAYERLEFTGROUND_H

--- a/include/events/PlayerOnGround.h
+++ b/include/events/PlayerOnGround.h
@@ -1,0 +1,23 @@
+//
+// Created by Agamjeet Singh on 19/08/25.
+//
+
+#ifndef PLAYERONGROUND_H
+#define PLAYERONGROUND_H
+#include "Contact.h"
+#include "entity/CollidableObject.h"
+#include "../entity/player/Player.h"
+
+
+struct PlayerOnGround {
+    explicit PlayerOnGround(Contact contact);
+
+    CollidableObject& surface;
+    Player& player;
+    sf::FloatRect surfaceRect;
+    sf::FloatRect playerRect;
+};
+
+
+
+#endif //PLAYERONGROUND_H

--- a/include/physics/CollisionsHandler.h
+++ b/include/physics/CollisionsHandler.h
@@ -99,7 +99,7 @@ public:
      * @param deltaTime The time (in seconds) to update the physics by
      * @param player The player whose inputs are to be handled
      */
-    void update(float deltaTime, Player& player);
+    void update(float deltaTime);
 
     /**
      * @brief Draws the hitbox of each registered body to the given window with the given color with an alpha value of
@@ -156,7 +156,7 @@ private:
      * @return The list of contacts that will be happening in deltaTime.
      */
     [[deprecated("Use buildContactsFaster() instead since it uses spatial hashing")]]
-    ContactsPtrHashMap buildContacts(float deltaTime) const;
+    [[nodiscard]] ContactsPtrHashMap buildContacts(float deltaTime) const;
 
     std::unordered_map<std::pair<CollidableObject*, CollidableObject*>, Collision, CollidableObjectPtrPairHash> buildContactsFaster(float deltaTime);
     ContactsPtrHashMap buildContactsFaster(float deltaTime);

--- a/include/physics/CollisionsHandler.h
+++ b/include/physics/CollisionsHandler.h
@@ -158,7 +158,7 @@ private:
     [[deprecated("Use buildContactsFaster() instead since it uses spatial hashing")]]
     [[nodiscard]] ContactsPtrHashMap buildContacts(float deltaTime) const;
 
-    std::unordered_map<std::pair<CollidableObject*, CollidableObject*>, Collision, CollidableObjectPtrPairHash> buildContactsFaster(float deltaTime);
+
     ContactsPtrHashMap buildContactsFaster(float deltaTime);
 
     // TODO - Should take in acceleration too with s = ut + 1/2at^2

--- a/include/physics/CollisionsHandler.h
+++ b/include/physics/CollisionsHandler.h
@@ -54,6 +54,9 @@ struct CollidableObjectPtrPairHash {
     }
 };
 
+using ContactsPtrHashMap = std::unordered_map<std::pair<CollidableObject*, CollidableObject*>, Collision, CollidableObjectPtrPairHash>;
+using BodiesHashTable = std::unordered_set<std::reference_wrapper<CollidableObject>, CollidableObjectRefHash, CollidableObjectRefEqual>;
+
 class CollisionsHandler {
 public:
     /**
@@ -80,36 +83,80 @@ public:
      */
     void removeObject(CollidableObject& body);
 
+    /**
+     * @brief Resets the CollisionsHandler by removing all the bodies registered in it.
+     */
     void reset() {
         bodies = {};
     }
 
+    /**
+     * @brief Updates the whole physics by the given time, including the player inputs.
+     * First builds the list of contacts according to predicted position in deltaTime, moves the immovable objects
+     * according to swept collision, then moves the movable objects. Then iteratively does impulse based resolution of
+     * all the contacts. Resets friction to zero for objects no longer resting on a surface.
+     *
+     * @param deltaTime The time (in seconds) to update the physics by
+     * @param player The player whose inputs are to be handled
+     */
     void update(float deltaTime, Player& player);
 
+    /**
+     * @brief Draws the hitbox of each registered body to the given window with the given color with an alpha value of
+     * \code 64\endcode.
+     * @param window The window to draw the hitboxes in.
+     * @param color The color of the hitbox, red by default.
+     */
     void drawHitboxes(sf::RenderWindow& window, sf::Color color = sf::Color::Red) const;
 
-    [[nodiscard]] float getCellSize(bool update = false) const {
-        static float cellSize = -1;
-        if (cellSize == -1 || update) {
-            cellSize = getNewCellSize();
-        }
-        return cellSize;
-    }
+    /**
+     * @brief Gets the cell size of the spatial hash. Updating the cell size takes O(N) time where N is the number of
+     * bodies. Cell size should only be updated when the \code bodies\endcode member has changed significantly.
+     * @param update Whether to get a new cell size according to the current bodies or not
+     * @return The cell size, an updated one if \code update\endcode was true.
+     */
+    [[nodiscard]] float getCellSize(bool update = false) const;
 
 private:
-    std::unordered_set<std::reference_wrapper<CollidableObject>, CollidableObjectRefHash, CollidableObjectRefEqual> bodies;
+    /**
+     * @brief The hash table that stores all the bodies.
+     */
+    BodiesHashTable bodies;
 
-    static float dot(const sf::Vector2f& first, const sf::Vector2f& second) {
-        return first.x * second.x + first.y * second.y;
-    }
-
+    /**
+     * @brief Gets the penetration of two rectangles in a collision. Used in positional correction.
+     * @param rectA The first rectangle.
+     * @param rectB The second rectangle.
+     * @param axis The axis of the collision of the two rectangles.
+     * @return the penetration along the axis (Vertical or Horizontal) between the two rectangles or \code 0\endcode if
+     * they don't intersect at all.
+     */
     static float getPenetration(sf::FloatRect rectA, sf::FloatRect rectB, CollisionAxis axis);
 
+    /**
+     * @brief Moves all the immovable objects by the given amount of time with swept collision since impulse based
+     * resolution would not work on two objects of infinite mass. Upon collision, both object's velocity and
+     * acceleration are set to zero.
+     * @param deltaTime The time (in seconds) to move the immovable objects by.
+     */
     void moveImmovables(float deltaTime) const;
 
+    /**
+     * @brief Moves all the movable objects by the given amount of time without any swept collision. Allows
+     * penetration which would later be dealt with by impulse resolution.
+     * @param deltaTime The time (in seconds) to move the movable objects by.
+     */
     void moveMovables(float deltaTime) const;
 
-    std::unordered_map<std::pair<CollidableObject*, CollidableObject*>, Collision, CollidableObjectPtrPairHash> buildContacts(float deltaTime);
+    // TODO - remove swept collision at all from buildContacts and buildContactsFaster and put it after moveMovables()
+    // and moveImmovables()
+    /**
+     * @brief
+     * @param deltaTime Builds the contacts hash map
+     * @return The list of contacts that will be happening in deltaTime.
+     */
+    [[deprecated("Use buildContactsFaster() instead since it uses spatial hashing")]]
+    ContactsPtrHashMap buildContacts(float deltaTime) const;
 
     std::unordered_map<std::pair<CollidableObject*, CollidableObject*>, Collision, CollidableObjectPtrPairHash> buildContactsFaster(float deltaTime);
 
@@ -125,6 +172,11 @@ private:
 
     void buildSpatialMap();
 
+    /**
+     * @brief Gets the cell size for spatial hashing. It takes O(N) time where N is the number of bodies. Should only
+     * be called when the \code bodies\endcode member has changed significantly.
+     * @return the cell size for spatial hashing. Currently implemented as the maximum diameter of any body.
+     */
     [[nodiscard]] float getNewCellSize() const;
 
 };

--- a/include/physics/CollisionsHandler.h
+++ b/include/physics/CollisionsHandler.h
@@ -159,6 +159,7 @@ private:
     ContactsPtrHashMap buildContacts(float deltaTime) const;
 
     std::unordered_map<std::pair<CollidableObject*, CollidableObject*>, Collision, CollidableObjectPtrPairHash> buildContactsFaster(float deltaTime);
+    ContactsPtrHashMap buildContactsFaster(float deltaTime);
 
     // TODO - Should take in acceleration too with s = ut + 1/2at^2
     static std::optional<IncompleteCollision> sweptCollision(
@@ -169,6 +170,8 @@ private:
         float deltaTime);
 
     SpacialHashMap spacial_map;
+
+    ContactsPtrHashMap next_frame_contacts;
 
     void buildSpatialMap();
 

--- a/include/physics/ContactsHandler.h
+++ b/include/physics/ContactsHandler.h
@@ -8,21 +8,38 @@
 #include "../entity/CollidableObject.h"
 #include "../events/Contact.h"
 #include "CollisionsHandler.h"
+#include <ranges>
 
 class Player;
 enum class Facing;
 
-struct ContactKeyHash {
-    std::size_t operator()(const std::pair<std::reference_wrapper<CollidableObject>, std::reference_wrapper<CollidableObject>>& key) const {
-        return std::hash<void*>{}(&key.first.get()) ^ std::hash<void*>{}(&key.second.get());
+/**
+ * Hash function for \code std::reference_wrapper<const Collider>\endcode
+ */
+struct CollidableObjectConstRefHash {
+    using is_transparent = void;
+    std::size_t operator()(const std::reference_wrapper<const CollidableObject>& ref) const noexcept {
+        return std::hash<const CollidableObject*>{}(&ref.get());
+    }
+
+    std::size_t operator()(const CollidableObject& obj) const noexcept {
+        return std::hash<const CollidableObject*>{}(&obj);
     }
 };
 
-struct ContactKeyEqual {
-    bool operator()(
-        const std::pair<std::reference_wrapper<CollidableObject>, std::reference_wrapper<CollidableObject> > &lhs,
-                   const std::pair<std::reference_wrapper<CollidableObject>, std::reference_wrapper<CollidableObject>>& rhs) const {
-        return &lhs.first.get() == &rhs.first.get() && &lhs.second.get() == &rhs.second.get();
+/**
+ * Equality function for \code std::reference_wrapper<const Collider>\endcode
+ */
+struct CollidableObjectConstRefEqual {
+    using is_transparent = void;
+    bool operator()(const std::reference_wrapper<const CollidableObject>& lhs, const std::reference_wrapper<const CollidableObject>& rhs) const noexcept {
+        return &lhs.get() == &rhs.get();
+    }
+    bool operator()(const std::reference_wrapper<const CollidableObject>& lhs, const CollidableObject& rhs) const noexcept {
+        return &lhs.get() == &rhs;
+    }
+    bool operator()(const CollidableObject& lhs, const std::reference_wrapper<const CollidableObject>& rhs) const noexcept {
+        return &lhs == &rhs.get();
     }
 };
 
@@ -37,24 +54,25 @@ public:
      */
     void addContact(Contact contact);
 
-    void removeContact(Contact contact);
-
-    void reset();
-
-    [[nodiscard]] std::optional<Contact> areTouching(CollidableObject& objectA, CollidableObject& objectB) const;
+    void newFrame();
 
     [[nodiscard]] std::vector<Contact> allContacts(const CollidableObject& object) const;
 
-    [[nodiscard]] bool onLand(const CollidableObject& object) const;
+    [[nodiscard]] bool onLand(const CollidableObject& object, bool previous_frame = false) const;
 
-    [[nodiscard]] std::vector<CollidableObject> nextToVerticalSurfaces(const CollidableObject& object) const;
+    [[nodiscard]] std::vector<CollidableObject> nextToVerticalSurfaces(const CollidableObject& object, bool previous_frame = false) const;
 
-    [[nodiscard]] std::vector<Contact> restingOnSurfaces(const CollidableObject& object) const;
+    [[nodiscard]] std::vector<Contact> restingOnSurfaces(const CollidableObject& object, bool previous_frame = false) const;
 
-    [[nodiscard]] const std::unordered_map<std::pair<std::reference_wrapper<CollidableObject>, std::reference_wrapper<CollidableObject>>, Contact, ContactKeyHash, ContactKeyEqual>& getContacts() const;
+    [[nodiscard]] std::vector<Contact> getContacts() const;
+
+    void emitPlayerLeftGroundEvent() const;
 
 private:
-    std::unordered_map<std::pair<std::reference_wrapper<CollidableObject>, std::reference_wrapper<CollidableObject>>, Contact, ContactKeyHash, ContactKeyEqual> contacts;
+    std::unordered_map<std::reference_wrapper<const CollidableObject>, std::vector<Contact>, CollidableObjectConstRefHash, CollidableObjectConstRefEqual> contacts;
+    std::unordered_map<std::reference_wrapper<const CollidableObject>, std::vector<Contact>, CollidableObjectConstRefHash, CollidableObjectConstRefEqual> previous_frame_contacts;
+
+    std::vector<Contact> contacts_vector;
 };
 
 

--- a/include/physics/Hitbox.h
+++ b/include/physics/Hitbox.h
@@ -29,6 +29,8 @@ public:
 
     [[nodiscard]] sf::FloatRect getBounds() const;
 
+    [[nodiscard]] size_t getSize() const;
+
     /**
      * @brief Iterator to iterate over the shifted hitboxes
      */

--- a/include/physics/SpacialHashMap.h
+++ b/include/physics/SpacialHashMap.h
@@ -15,6 +15,11 @@ public:
     [[nodiscard]] size_t getSize() const {
         return num_buckets;
     }
+
+    [[nodiscard]] size_t getNumObjects() const {
+        return num_objects;
+    }
+
     void clear();
 
     void addObject(CollidableObject* ptr);
@@ -25,6 +30,8 @@ private:
     std::vector<std::vector<CollidableObject*>> buckets;
 
     size_t num_buckets;
+
+    size_t num_objects = 0;
 
     static std::vector<size_t> getHashes(const CollidableObject* ptr);
 

--- a/include/utility/InputManager.h
+++ b/include/utility/InputManager.h
@@ -5,8 +5,14 @@
 #ifndef INPUTMANAGER_H
 #define INPUTMANAGER_H
 
+#include <cassert>
+#include <SFML/System.hpp>
 #include <SFML/Window/Keyboard.hpp>
 #include <unordered_map>
+
+namespace sf {
+    class Time;
+}
 
 /**
  * \brief Manages all inputs. Can be used to check whether a key is currently being pressed. A better alternative to

--- a/include/utility/ScheduledEvent.h
+++ b/include/utility/ScheduledEvent.h
@@ -16,8 +16,16 @@ struct ScheduledEvent {
     float spentTime = 0;
     float maxTime;
 
+    bool cancelled = false;
+
+    // TODO - Overload constructor to make it simpler. Separate constructors for repeating and non-repeating events.
+
     ScheduledEvent(std::function<void()> cb, float time, bool repeat = false, float interval = 0, float maxTime = -1)
-        : timeRemaining(time), callback(std::move(cb)), repeat(repeat), interval(interval), maxTime(maxTime) {
+        : timeRemaining(time), callback([this, cb]() {
+            if (!this->cancelled) {
+                cb();
+            }
+        }), repeat(repeat), interval(interval), maxTime(maxTime) {
         assert(repeat || (maxTime == -1)); // If repeat is false then maxTime must be -1
         assert(!repeat || (maxTime > 0)); // If repeat is true then maxTime must be positive
     }

--- a/include/utility/ScheduledEvent.h
+++ b/include/utility/ScheduledEvent.h
@@ -27,7 +27,7 @@ struct ScheduledEvent {
             }
         }), repeat(repeat), interval(interval), maxTime(maxTime) {
         assert(repeat || (maxTime == -1)); // If repeat is false then maxTime must be -1
-        assert(!repeat || (maxTime > 0)); // If repeat is true then maxTime must be positive
+        assert(!repeat || (maxTime > 0 || maxTime == -1)); // If repeat is true then maxTime must be positive or default -1
     }
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -99,13 +99,13 @@ int main() {
 
 
         std::cout << "Player 1 x: " << player.getSprite().getPosition().x << "y: " << player.getSprite().getPosition().y << std::endl;
-        std::cout << "Player 2 x: " << player2.getSprite().getPosition().x << "y: " << player2.getSprite().getPosition().y << std::endl;
+        // std::cout << "Player 2 x: " << player2.getSprite().getPosition().x << "y: " << player2.getSprite().getPosition().y << std::endl;
         std::cout << "Player 1 Hitbox x: " << player.getHitbox().getRects()[0].position.x << "y: " << player.getHitbox().getRects()[0].position.y << std::endl;
-        std::cout << "Player 2 Hitbox x: " << player2.getHitbox().getRects()[0].position.x << "y: " << player2.getHitbox().getRects()[0].position.y << std::endl;
+        // std::cout << "Player 2 Hitbox x: " << player2.getHitbox().getRects()[0].position.x << "y: " << player2.getHitbox().getRects()[0].position.y << std::endl;
         player.printVelocity("Player 1");
-        player2.printVelocity("Player 2");
-        std::cout << "Player 1 Acceleration x: " << player.acceleration.x << "y: " << player.acceleration.y << std::endl;
-        std::cout << "Player 2 Acceleration x: " << player2.acceleration.x << "y: " << player2.acceleration.y << std::endl;
+        // player2.printVelocity("Player 2");
+        std::cout << "Player 1 Acceleration x: " << player.gravity_acceleration.x << "y: " << player.gravity_acceleration.y << std::endl;
+        // std::cout << "Player 2 Acceleration x: " << player2.gravity_acceleration.x << "y: " << player2.gravity_acceleration.y << std::endl;
         std::cout << CollisionsHandler::getInstance().getBodies().size() << std::endl;
         std::cout << "--------------------" << std::endl;
 

--- a/main.cpp
+++ b/main.cpp
@@ -63,8 +63,9 @@ int main() {
 
         window.clear(sf::Color::White);
 
-        CollisionsHandler::getInstance().update(dt, player);
         EventBus::getInstance().execute(EventExecuteTime::PRE_INPUT);
+
+        PlayerInputHandler{player}.update(dt);
 
         EventBus::getInstance().execute(EventExecuteTime::PRE_PHYSICS);
 

--- a/src/entity/CollidableObject.cpp
+++ b/src/entity/CollidableObject.cpp
@@ -41,3 +41,8 @@ bool CollidableObject::operator==(const CollidableObject &other) const {
 [[nodiscard]] Player* CollidableObject::isPlayer() {
     return dynamic_cast<Player*>(this);
 }
+
+[[nodiscard]] const Player *CollidableObject::isPlayer() const {
+    return dynamic_cast<const Player*>(this);
+}
+

--- a/src/entity/CollidableObject.cpp
+++ b/src/entity/CollidableObject.cpp
@@ -25,6 +25,11 @@ CollidableObject::CollidableObject(std::vector<sf::FloatRect> hitbox,
     CollisionsHandler::getInstance().addObject(*this);
 }
 
+[[nodiscard]] float CollidableObject::getInvMass() const {
+    return (mass == 0) ? 0 : (1.0f / mass);
+}
+
+
 [[nodiscard]] const Hitbox& CollidableObject::getHitbox() const {
     return hitbox;
 }
@@ -33,6 +38,6 @@ bool CollidableObject::operator==(const CollidableObject &other) const {
     return this == &other;
 }
 
-Player* CollidableObject::isPlayer() {
+[[nodiscard]] Player* CollidableObject::isPlayer() {
     return dynamic_cast<Player*>(this);
 }

--- a/src/entity/PhysicsObject.cpp
+++ b/src/entity/PhysicsObject.cpp
@@ -10,8 +10,20 @@ PhysicsObject::PhysicsObject(sf::Sprite sprite, sf::Vector2f position = {0, 0}) 
     this->sprite.setPosition(position);
 }
 
-void PhysicsObject::update(float deltaTime) {
-    sprite.setPosition(position);
+const sf::Vector2f &PhysicsObject::getPositionRef() const {
+    return position;
+}
+
+void PhysicsObject::setGravityVelocity(sf::Vector2f velocity) {
+    assert(velocity.x == 0);
+    gravity_velocity = velocity;
+    gravity_velocity.y = std::min(gravity_velocity.y, MAX_FALL);
+}
+
+void PhysicsObject::addGravityVelocity(sf::Vector2f velocity) {
+    assert(velocity.x == 0);
+    gravity_velocity += velocity;
+    gravity_velocity.y = std::min(gravity_velocity.y, MAX_FALL);
 }
 
 const sf::Sprite& PhysicsObject::getSprite() const {
@@ -33,7 +45,22 @@ void PhysicsObject::addPosition(sf::Vector2f position) {
 }
 
 sf::Vector2f PhysicsObject::getTotalVelocity() const {
-    return intrinsic_velocity + friction_velocity + impulse_velocity;
+    return intrinsic_velocity + friction_velocity + impulse_velocity + gravity_velocity;
 }
 
+void PhysicsObject::printVelocity(const std::string &name) const {
+    std::cout << name << " intrinsic_velocity: x = " << intrinsic_velocity.x << ", y = " << intrinsic_velocity.y << std::endl;
+    std::cout << name << " friction_velocity: x = " << friction_velocity.x << ", y = " << friction_velocity.y << std::endl;
+    std::cout << name << " impulse_velocity: x = " << impulse_velocity.x << ", y = " << impulse_velocity.y << std::endl;
+}
+
+void PhysicsObject::printVelocity() const {
+    printVelocity(getAddressAsString());
+}
+
+std::string PhysicsObject::getAddressAsString() const {
+    std::ostringstream oss;
+    oss << this;
+    return oss.str();
+}
 

--- a/src/entity/player/PlayerInputHandler.cpp
+++ b/src/entity/player/PlayerInputHandler.cpp
@@ -3,3 +3,132 @@
 //
 
 #include "entity/player/PlayerInputHandler.h"
+
+void PlayerInputHandler::update(float deltaTime) {
+    if (&player.getState() == &PlayerStateGround::getInstance()) {
+        updateFromGroundState(deltaTime);
+        return;
+    }
+
+    if (&player.getState() == &PlayerStateAir::getInstance()) {
+        updateFromAirState(deltaTime);
+        return;
+    }
+
+    if (&player.getState() == &PlayerStateClimbing::getInstance()) {
+        updateFromClimbState(deltaTime);
+        return;
+    }
+}
+
+void PlayerInputHandler::updateFromGroundState(float deltaTime) {
+    assert(&player.getState() == &PlayerStateGround::getInstance());
+
+    if (isPressed(dashKey)) {
+        if (bool success = player.tryDash(getDashDirection())) return;
+    }
+
+    if (isPressed(climbKey)) {
+        if (bool success = player.tryClimb()) return;
+    }
+
+    if (isPressed(jumpKey)) {
+        if (bool success = player.tryJump()) return;
+    }
+
+    bool moveSomewhere = false;
+
+    if (isPressed(moveLeft) && (!isPressed(moveRight) || wasPressedEarlierThan(moveRight, moveLeft))) {
+        // Move left
+        moveSomewhere = true;
+        player.facing = Facing::Left;
+        approach(player.intrinsic_velocity.x, -Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime);
+    }
+
+    if (isPressed(moveRight) && (!isPressed(moveLeft) || wasPressedEarlierThan(moveLeft, moveRight))) {
+        // Move right
+        moveSomewhere = true;
+        player.facing = Facing::Right;
+        approach(player.intrinsic_velocity.x, Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime);
+    }
+
+    if (!moveSomewhere) {
+        approach(player.intrinsic_velocity.x, 0, Player::RUN_ACCELERATION * deltaTime);
+    }
+}
+
+void PlayerInputHandler::updateFromAirState(float deltaTime) {
+    assert(&player.getState() == &PlayerStateAir::getInstance());
+}
+
+void PlayerInputHandler::updateFromClimbState(float deltaTime) {
+    assert(&player.getState() == &PlayerStateClimbing::getInstance());
+}
+
+void PlayerInputHandler::approach(float &to_make_approach, float to_approach, float step) {
+    assert(step >= 0);
+    if (to_make_approach > to_approach) {
+        to_make_approach = std::max(to_make_approach - step, to_approach);
+    } else if (to_make_approach < to_approach) {
+        to_make_approach = std::min(to_make_approach + step, to_approach);
+    }
+}
+
+
+DashDirection PlayerInputHandler::getDashDirection() {
+    std::optional<Key> verticalKey;
+    std::optional<Key> horizontalKey;
+
+    if (isPressed(moveUp)) {
+        if (isPressed(moveDown)) {
+            verticalKey = wasPressedEarlierThan(moveUp, moveDown) ? moveDown : moveUp;
+        } else {
+            verticalKey = moveUp;
+        }
+    } else {
+        if (isPressed(moveDown)) {
+            verticalKey = moveDown;
+        }
+    }
+
+    if (isPressed(moveLeft)) {
+        if (isPressed(moveRight)) {
+            horizontalKey = wasPressedEarlierThan(moveLeft, moveRight) ? moveRight : moveLeft;
+        } else {
+            horizontalKey = moveLeft;
+        }
+    } else {
+        if (isPressed(moveRight)) {
+            horizontalKey = moveRight;
+        }
+    }
+
+    DashDirection direction = Player::DEFAULT_DASH_DIRECTION;
+
+    if (verticalKey) {
+        if (horizontalKey) {
+            if (verticalKey == moveUp && horizontalKey == moveLeft) {
+                direction = DashDirection::UP_LEFT;
+            }
+            if (verticalKey == moveUp && horizontalKey == moveRight) {
+                direction = DashDirection::UP_RIGHT;
+            }
+            if (verticalKey == moveDown && horizontalKey == moveLeft) {
+                direction = DashDirection::DOWN_LEFT;
+            }
+            if (verticalKey == moveDown && horizontalKey == moveRight) {
+                direction = DashDirection::DOWN_RIGHT;
+            }
+        } else {
+            direction = verticalKey == moveUp ? DashDirection::UP : DashDirection::DOWN;
+        }
+    } else {
+        if (horizontalKey) {
+            direction = horizontalKey == moveLeft ? DashDirection::LEFT : DashDirection::RIGHT;
+        }
+    }
+
+    return direction;
+}
+
+

--- a/src/entity/player/PlayerSpriteState.cpp
+++ b/src/entity/player/PlayerSpriteState.cpp
@@ -1,6 +1,0 @@
-//
-// Created by Agamjeet Singh on 25/07/25.
-//
-
-#include "entity/player/PlayerSpriteState.h"
-

--- a/src/events/Contact.cpp
+++ b/src/events/Contact.cpp
@@ -4,10 +4,22 @@
 
 #include "events/Contact.h"
 
+#include "entity/CollidableObject.h"
+
 bool Contact::operator==(const Contact &other) const {
     return &objectA == &other.objectA &&
            &objectB == &other.objectB &&
-           collidingRectA == other.collidingRectA &&
-           collidingRectB == other.collidingRectB &&
+           collidingRectAIndex == other.collidingRectAIndex &&
+           collidingRectBIndex == other.collidingRectBIndex &&
            axis == other.axis;
 }
+
+sf::FloatRect Contact::getCollidingRectA() const {
+    return objectA.getHitbox().getRects()[collidingRectAIndex];
+}
+
+sf::FloatRect Contact::getCollidingRectB() const {
+    return objectB.getHitbox().getRects()[collidingRectBIndex];
+}
+
+

--- a/src/events/Event.cpp
+++ b/src/events/Event.cpp
@@ -4,18 +4,4 @@
 
 #include "../../include/events/Event.h"
 
-template<typename T>
-Event::Event(T event, EventExecuteTime execute_time): type_index(typeid(event)), execute_time(execute_time), meta_data(std::make_shared<GeneralEvent<T>>(std::move(event))) {}
-
-template<typename EventType>
-const EventType *Event::getIf() const {
-    if (type_index != typeid(EventType)) return nullptr;
-    auto ptr = dynamic_cast<GeneralEvent<EventType>*>(&meta_data);
-    return ptr ? &ptr->data : nullptr;
-}
-
-template<typename EventType>
-bool Event::is() const {
-    return type_index == typeid(EventType);
-}
 

--- a/src/events/Event.cpp
+++ b/src/events/Event.cpp
@@ -1,0 +1,21 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#include "../../include/events/Event.h"
+
+template<typename T>
+Event::Event(T event, EventExecuteTime execute_time): type_index(typeid(event)), execute_time(execute_time), meta_data(std::make_shared<GeneralEvent<T>>(std::move(event))) {}
+
+template<typename EventType>
+const EventType *Event::getIf() const {
+    if (type_index != typeid(EventType)) return nullptr;
+    auto ptr = dynamic_cast<GeneralEvent<EventType>*>(&meta_data);
+    return ptr ? &ptr->data : nullptr;
+}
+
+template<typename EventType>
+bool Event::is() const {
+    return type_index == typeid(EventType);
+}
+

--- a/src/events/EventBus.cpp
+++ b/src/events/EventBus.cpp
@@ -1,0 +1,52 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#include "../../include/events/EventBus.h"
+
+EventBus &EventBus::getInstance() {
+    static EventBus instance;
+    return instance;
+}
+
+void EventBus::emit(Event event) {
+    if (!listeners.contains(event.type_index)) return;
+
+    if (event.execute_time == EventExecuteTime::NOW) {
+        executeNow(event);
+        return;
+    }
+    events_by_execution[event.execute_time].push(std::move(event));
+}
+
+
+void EventBus::executeNow(Event event) const {
+    assert(event.execute_time == EventExecuteTime::NOW);
+    auto& multiset = listeners.at(event.type_index);
+    for (const Listener& listener: multiset) {
+        listener.call(&event);
+    }
+}
+
+void EventBus::execute(EventExecuteTime time) {
+    auto& events = events_by_execution[time];
+    while (!events.empty()) {
+        Event event = events.front();
+        events.pop();
+        auto& multiset = listeners[event.type_index];
+        for (const Listener& listener: multiset) {
+            listener.call(&event);
+        }
+    }
+}
+
+void EventBus::registerListener(Listener listener) {
+    listeners[listener.type_index].insert(std::move(listener));
+}
+
+
+
+
+
+
+

--- a/src/events/EventBus.cpp
+++ b/src/events/EventBus.cpp
@@ -4,6 +4,10 @@
 
 #include "../../include/events/EventBus.h"
 
+#include <cassert>
+
+#include "events/Listener.h"
+
 EventBus &EventBus::getInstance() {
     static EventBus instance;
     return instance;

--- a/src/events/Listener.cpp
+++ b/src/events/Listener.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Agamjeet Singh on 17/08/25.
+//
+
+#include "../../include/events/Listener.h"
+
+
+void Listener::call(const void *ev) const {
+    erased_cb(ev);
+}
+
+
+

--- a/src/events/PlayerLeftGround.cpp
+++ b/src/events/PlayerLeftGround.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Agamjeet Singh on 19/08/25.
+//
+
+#include "../../include/events/PlayerLeftGround.h"

--- a/src/events/PlayerOnGround.cpp
+++ b/src/events/PlayerOnGround.cpp
@@ -1,0 +1,10 @@
+//
+// Created by Agamjeet Singh on 19/08/25.
+//
+
+#include "../../include/events/PlayerOnGround.h"
+
+PlayerOnGround::PlayerOnGround(Contact contact) : surface(contact.objectA.isPlayer() ? contact.objectB : contact.objectA),
+    player(contact.objectA.isPlayer() ? *contact.objectA.isPlayer() : *contact.objectB.isPlayer()),
+    surfaceRect(contact.objectA.isPlayer() ? contact.getCollidingRectB() : contact.getCollidingRectA()),
+    playerRect(contact.objectA.isPlayer() ? contact.getCollidingRectA() : contact.getCollidingRectB()) {}

--- a/src/physics/CollisionsHandler.cpp
+++ b/src/physics/CollisionsHandler.cpp
@@ -465,7 +465,12 @@ void CollisionsHandler::drawHitboxes(sf::RenderWindow &window, sf::Color color) 
 void CollisionsHandler::buildSpatialMap() {
     auto updated = getCellSize(true);
 
-    spacial_map = SpacialHashMap{bodies.size()};
+    if (bodies.size() != spacial_map.getNumObjects()) {
+        spacial_map = SpacialHashMap{bodies.size()};
+    } else {
+        spacial_map.clear();
+    }
+
 
     for (const auto& body: bodies) {
         spacial_map.addObject(&body.get());

--- a/src/physics/CollisionsHandler.cpp
+++ b/src/physics/CollisionsHandler.cpp
@@ -46,23 +46,10 @@ void CollisionsHandler::removeObject(CollidableObject& body) {
     bodies.erase(std::ref(body));
 }
 
-void CollisionsHandler::update(float deltaTime, Player& player) {
-
-    auto contacts = buildContactsFaster(deltaTime);
-
-    moveImmovables(deltaTime);
-    moveMovables(deltaTime);
+void CollisionsHandler::update(float deltaTime) {
 
     for (const auto& body: bodies) {
-        constexpr float lambda = 10;
-        // body.get().impulse_velocity *= std::exp(-lambda * deltaTime);
         body.get().impulse_velocity *= 0.0f;
-        // if (body.get().impulse_velocity.x < 0.1) {
-        //     body.get().impulse_velocity.x = 0;
-        // }
-        // if (body.get().impulse_velocity.y < 0.1) {
-        //     body.get().impulse_velocity.y = 0;
-        // }
     }
 
     PlayerInputHandler{player}.update(deltaTime);
@@ -70,8 +57,8 @@ void CollisionsHandler::update(float deltaTime, Player& player) {
     std::unordered_set<CollidableObject*> friction_set_bodies;
 
     for (int i = 0; i < 8; i++) {
-        for (const auto& key: contacts | std::views::keys) {
-            auto collision = contacts.at(key);
+        for (const auto& key: next_frame_contacts | std::views::keys) {
+            auto collision = next_frame_contacts.at(key);
             auto normal = -axisToVector(collision.axis); // A moving towards B in this normal
             // Compute Penetration
             auto penetrationDepth = getPenetration(collision.getCollidingRectA(), collision.getCollidingRectB(),
@@ -141,6 +128,11 @@ void CollisionsHandler::update(float deltaTime, Player& player) {
             body.get().friction_velocity = {0, 0};
         }
     }
+
+    next_frame_contacts = buildContactsFaster(deltaTime);
+
+    moveImmovables(deltaTime);
+    moveMovables(deltaTime);
 }
 
 

--- a/src/physics/CollisionsHandler.cpp
+++ b/src/physics/CollisionsHandler.cpp
@@ -162,10 +162,10 @@ void CollisionsHandler::moveImmovables(float deltaTime) const {
         for (auto bodyB: immovables) {
             // ~O(1) nested for loop, very few rectangles in every hitbox
             std::unordered_map<Collision, float, CollisionHash> body_ab_collisions;
-            for (std::size_t indexA = 0; indexA < bodyA.get().getHitbox().getRects().size(); indexA++) {
-                auto rectA = bodyA.get().getHitbox().getRects()[indexA];
-                for (std::size_t indexB = 0; indexB < bodyB.get().getHitbox().getRects().size(); indexB++) {
-                    auto rectB = bodyB.get().getHitbox().getRects()[indexB];
+            size_t indexA = 0;
+            for (const auto& rectA : bodyA.get().getHitbox()) {
+                size_t indexB = 0;
+                for (const auto& rectB : bodyB.get().getHitbox()) {
                     if (&bodyA.get() <= &bodyB.get()) {
                         continue;
                     }
@@ -179,7 +179,9 @@ void CollisionsHandler::moveImmovables(float deltaTime) const {
                     if (incompleteCollision) {
                         body_ab_collisions[Collision{bodyA, bodyB, incompleteCollision.value(), indexA, indexB}] = incompleteCollision->collisionTime;
                     }
+                    indexB++;
                 }
+                indexA++;
             }
 
             // Sort for earliest collision by time to get the sf::FloatRects and add it to the collisions map
@@ -300,11 +302,11 @@ ContactsPtrHashMap CollisionsHandler::buildContactsFaster(float deltaTime) {
         float earliestTime = std::numeric_limits<float>::max();
         std::optional<IncompleteCollision> earliestCollision;
         std::size_t earliestIndexA = 0, earliestIndexB = 0;
-        
-        for (std::size_t indexA = 0; indexA < bodyA->getHitbox().getRects().size(); indexA++) {
-            auto rectA = bodyA->getHitbox().getRects()[indexA];
-            for (std::size_t indexB = 0; indexB < bodyB->getHitbox().getRects().size(); indexB++) {
-                auto rectB = bodyB->getHitbox().getRects()[indexB];
+
+        size_t indexA = 0;
+        for (const auto& rectA : bodyA->getHitbox()) {
+            size_t indexB = 0;
+            for (const auto& rectB : bodyB->getHitbox()) {
                 auto incompleteCollision =
                     sweptCollision(
                         rectA,
@@ -320,7 +322,9 @@ ContactsPtrHashMap CollisionsHandler::buildContactsFaster(float deltaTime) {
                         earliestIndexB = indexB;
                     }
                 }
+                indexB++;
             }
+            indexA++;
         }
         
         if (earliestCollision.has_value()) {

--- a/src/physics/CollisionsHandler.cpp
+++ b/src/physics/CollisionsHandler.cpp
@@ -53,6 +53,17 @@ void CollisionsHandler::update(float deltaTime, Player& player) {
     moveImmovables(deltaTime);
     moveMovables(deltaTime);
 
+    for (const auto& body: bodies) {
+        constexpr float lambda = 10;
+        // body.get().impulse_velocity *= std::exp(-lambda * deltaTime);
+        body.get().impulse_velocity *= 0.0f;
+        // if (body.get().impulse_velocity.x < 0.1) {
+        //     body.get().impulse_velocity.x = 0;
+        // }
+        // if (body.get().impulse_velocity.y < 0.1) {
+        //     body.get().impulse_velocity.y = 0;
+        // }
+    }
 
     PlayerInputHandler{player}.update(deltaTime);
 

--- a/src/physics/CollisionsHandler.cpp
+++ b/src/physics/CollisionsHandler.cpp
@@ -52,8 +52,6 @@ void CollisionsHandler::update(float deltaTime) {
         body.get().impulse_velocity *= 0.0f;
     }
 
-    PlayerInputHandler{player}.update(deltaTime);
-
     std::unordered_set<CollidableObject*> friction_set_bodies;
 
     for (int i = 0; i < 8; i++) {
@@ -320,7 +318,7 @@ ContactsPtrHashMap CollisionsHandler::buildContactsFaster(float deltaTime) {
         }
         
         if (earliestCollision.has_value()) {
-            contacts.emplace(std::make_pair(bodyA, bodyB), 
+            contacts.emplace(std::make_pair(bodyA, bodyB),
                            Collision{(*bodyA), (*bodyB), earliestCollision.value(), earliestIndexA, earliestIndexB});
         }
     }

--- a/src/physics/ContactsHandler.cpp
+++ b/src/physics/ContactsHandler.cpp
@@ -4,6 +4,9 @@
 
 #include "physics/ContactsHandler.h"
 #include "entity/player/Player.h"
+#include "events/EventBus.h"
+#include "events/PlayerLeftGround.h"
+#include "events/PlayerOnGround.h"
 
 ContactsHandler &ContactsHandler::getInstance() {
     static ContactsHandler instance;
@@ -11,80 +14,98 @@ ContactsHandler &ContactsHandler::getInstance() {
 }
 
 void ContactsHandler::addContact(Contact contact) {
-    auto key = std::make_pair(std::ref(contact.objectA), std::ref(contact.objectB));
-    contacts.erase(key);
-    contacts.emplace(key, contact);
+    auto keyA = std::ref(contact.objectA);
+    auto keyB = std::ref(contact.objectB);
+    contacts[keyA].push_back(contact);
     if (contact.objectA != contact.objectB) {
-        contacts.erase({contact.objectB, contact.objectA});
+        contacts[keyB].push_back(contact);
     }
-}
+    contacts_vector.push_back(contact);
 
-void ContactsHandler::removeContact(Contact contact) {
-    contacts.erase({std::ref(contact.objectA), std::ref(contact.objectB)});
-    contacts.erase({std::ref(contact.objectB), std::ref(contact.objectA)});
-}
+    if ((contact.objectA.isPlayer() || contact.objectB.isPlayer()) && contact.axis == ContactAxis::Y) {
+        const CollidableObject* player = contact.objectA.isPlayer() ? &contact.objectA : &contact.objectB;
+        const CollidableObject* other = contact.objectA.isPlayer() ? &contact.objectB : &contact.objectA;
 
-void ContactsHandler::reset() {
-    contacts.clear();
-}
-
-std::optional<Contact> ContactsHandler::areTouching(CollidableObject &objectA, CollidableObject &objectB) const {
-    auto key1 = std::make_pair(std::ref(objectA), std::ref(objectB));
-    auto key2 = std::make_pair(std::ref(objectB), std::ref(objectA));
-
-    if (contacts.contains(key1)) {
-        return contacts.at(key1);
-    } else if (contacts.contains(key2)) {
-        return contacts.at(key2);
-    } else {
-        return std::nullopt;
+        bool playerAboveOther = contact.objectA.isPlayer() ?
+            contact.getCollidingRectA().position.y < contact.getCollidingRectB().position.y :
+            contact.getCollidingRectB().position.y < contact.getCollidingRectA().position.y;
+            
+        if (playerAboveOther) {
+            EventBus::getInstance().emit(PlayerOnGround{contact}, EventExecuteTime::POST_PHYSICS);
+        }
     }
+    EventBus::getInstance().emit(contact, EventExecuteTime::POST_PHYSICS);
+}
+
+void ContactsHandler::newFrame() {
+    previous_frame_contacts = std::move(contacts);
+    contacts = decltype(contacts){};
+    contacts_vector.clear();
 }
 
 std::vector<Contact> ContactsHandler::allContacts(const CollidableObject &object) const {
-    std::vector<Contact> object_contacts;
-    for (const auto& keyValue: contacts) {
-        const auto [fst, snd] = keyValue.first;
-        if (fst.get() == object || snd.get() == object) {
-            object_contacts.push_back(keyValue.second);
-        }
-    }
-    return object_contacts;
+    const auto it = contacts.find(object);
+    return it == contacts.end() ? std::vector<Contact>{} : it->second;
 }
 
-bool ContactsHandler::onLand(const CollidableObject &object) const {
-    auto all_contacts = allContacts(object);
-    for (const auto& contact: all_contacts) {
-        if (contact.axis == ContactAxis::Y) {
-            return true;
-        }
+
+bool ContactsHandler::onLand(const CollidableObject &object, bool previous_frame) const {
+    auto& contacts = previous_frame ? previous_frame_contacts : this->contacts;
+    if (!contacts.contains(object)) {
+        return false;
     }
-    return false;
+    const auto it = contacts.find(object);
+    if (it == contacts.end()) {
+        return false;
+    }
+    const std::vector<Contact>& all_contacts = it->second;
+
+    return std::ranges::any_of(all_contacts, [&object](const Contact &contact) {
+        return contact.axis == ContactAxis::Y && (object == contact.objectA ? contact.getCollidingRectA().position.y < contact.getCollidingRectB().position.y : contact.getCollidingRectB().position.y < contact.getCollidingRectA().position.y);
+    });
 }
 
-std::vector<CollidableObject> ContactsHandler::nextToVerticalSurfaces(const CollidableObject &object) const {
+std::vector<CollidableObject> ContactsHandler::nextToVerticalSurfaces(const CollidableObject &object, bool previous_frame) const {
+    auto& contacts = previous_frame ? previous_frame_contacts : this->contacts;
     std::vector<CollidableObject> vertical_surfaces;
-    auto all_contacts = allContacts(object);
-    for (const auto& contact: all_contacts) {
-        if (contact.axis == ContactAxis::X) {
-            auto other_object = (contact.objectA == object) ? contact.objectB : contact.objectA;
-            vertical_surfaces.push_back(other_object);
-        }
+    if (!contacts.contains(object)) {
+        return {};
+    }
+    const auto it = contacts.find(object);
+    if (it == contacts.end()) {
+        return {};
+    }
+    const std::vector<Contact>& all_contacts = it->second;
+
+    for (const auto& contact: all_contacts | std::views::filter([](const Contact &contact){ return contact.axis == ContactAxis::X; })) {
+        auto other_object = (contact.objectA == object) ? contact.objectB : contact.objectA;
+        vertical_surfaces.push_back(other_object);
     }
     return vertical_surfaces;
 }
 
-std::vector<Contact> ContactsHandler::restingOnSurfaces(const CollidableObject &object) const {
+std::vector<Contact> ContactsHandler::restingOnSurfaces(const CollidableObject &object, bool previous_frame) const {
+    auto& contacts = previous_frame ? previous_frame_contacts : this->contacts;
     std::vector<Contact> horizontal_contacts;
-    auto all_contacts = allContacts(object);
-    for (const auto& contact: all_contacts) {
-        if (contact.axis == ContactAxis::Y) {
-            horizontal_contacts.push_back(contact);
-        }
+    if (!contacts.contains(object)) {
+        return {};
     }
+    const std::vector<Contact>& all_contacts = contacts.at(object);
+    auto pred = [object](const Contact &contact){ return contact.axis == ContactAxis::X && (object == contact.objectA ? contact.getCollidingRectA().position.y < contact.getCollidingRectB().position.y : contact.getCollidingRectB().position.y < contact.getCollidingRectA().position.y); };
+    std::ranges::copy_if(all_contacts, std::back_inserter(horizontal_contacts),pred);
     return horizontal_contacts;
 }
 
-[[nodiscard]] const std::unordered_map<std::pair<std::reference_wrapper<CollidableObject>, std::reference_wrapper<CollidableObject>>, Contact, ContactKeyHash, ContactKeyEqual>& ContactsHandler::getContacts() const{
-    return contacts;
+[[nodiscard]] std::vector<Contact> ContactsHandler::getContacts() const{
+    return contacts_vector;
 }
+
+void ContactsHandler::emitPlayerLeftGroundEvent() const {
+    EventBus& instance = EventBus::getInstance();
+    for (const auto& object: std::views::keys(previous_frame_contacts)) {
+        if (object.get().isPlayer() && onLand(object.get(), true) && !onLand(object.get())) {
+            EventBus::getInstance().emit(PlayerLeftGround{*object.get().isPlayer()}, EventExecuteTime::POST_PHYSICS);
+        }
+    }
+}
+

--- a/src/physics/Hitbox.cpp
+++ b/src/physics/Hitbox.cpp
@@ -23,7 +23,7 @@ sf::FloatRect Hitbox::getBounds() const {
     float bottommost_coord = first_hitbox.position.y + first_hitbox.size.y;
     float topmost_coord = first_hitbox.position.y;
 
-    for (auto box: *this) {
+    for (const auto& box: *this) {
         leftmost_coord = std::min(leftmost_coord, box.position.x);
         rightmost_coord = std::max(rightmost_coord, box.position.x + box.size.x);
         bottommost_coord = std::max(bottommost_coord, box.position.y + box.size.y);
@@ -60,3 +60,8 @@ bool Hitbox::Iterator::operator!=(const Iterator& other) const {
 [[nodiscard]] Hitbox::Iterator Hitbox::end() const {
     return Iterator(original_hitbox, original_hitbox.size(), position);
 }
+
+size_t Hitbox::getSize() const {
+    return original_hitbox.size();
+}
+

--- a/src/physics/SpacialHashMap.cpp
+++ b/src/physics/SpacialHashMap.cpp
@@ -36,7 +36,7 @@ std::vector<std::pair<CollidableObject *, CollidableObject *> > SpacialHashMap::
             }
         }
     }
-    return std::move(pairs);
+    return pairs;
 }
 
 std::vector<size_t> SpacialHashMap::getHashes(const CollidableObject *ptr) {

--- a/src/physics/SpacialHashMap.cpp
+++ b/src/physics/SpacialHashMap.cpp
@@ -13,6 +13,7 @@ void SpacialHashMap::clear() {
     for (auto &bucket : buckets) {
         bucket.clear();
     }
+    num_objects = 0;
 }
 
 
@@ -20,6 +21,7 @@ void SpacialHashMap::addObject(CollidableObject *ptr) {
     for (size_t hash: getHashes(ptr)) {
         buckets[hash % num_buckets].push_back(ptr);
     }
+    num_objects++;
 }
 
 std::vector<std::pair<CollidableObject *, CollidableObject *> > SpacialHashMap::getPairs() const {

--- a/src/physics/SpacialHashMap.cpp
+++ b/src/physics/SpacialHashMap.cpp
@@ -29,7 +29,7 @@ std::vector<std::pair<CollidableObject *, CollidableObject *> > SpacialHashMap::
     for (const auto& bucket: buckets) {
         for (auto ptr1: bucket) {
             for (auto ptr2: bucket) {
-                if (&ptr1 <= &ptr2) {
+                if (ptr1 <= ptr2) {
                     continue;
                 }
                 pairs.emplace_back(ptr1, ptr2);


### PR DESCRIPTION
Implemented EventBus and Listeners. Events can be emitted and listened to. Events are executed only at certain times (see EventExecuteTime) such as POST_PHYSICS. Listeners have priority amongst each other. Listener has type erasure and is not templated despite handling any event class.

Optimised Physics Engine. Did minor optimisations such as: Clearing the spacial map instead of destroying it each frame and fixing pairs being double the number they should be in Spacial map. Using iterators to iterate over the hitbox. Found many of these problems through the CLion Profiler.

Event Scheduler now returns std::shared_ptr and the abiltiy to cancel events through this pointer. ContactsHandler now has O(1) access to the contacts of an object. Stores both the current frame and the previous frame's contacts in order to emit events like PlayerLeftGround.