### PR TITLE
Redesigned velocity system

### DIFF
--- a/include/entity/PhysicsObject.h
+++ b/include/entity/PhysicsObject.h
@@ -35,36 +35,15 @@ public:
 
     // Public to make it easy to update just one of the components
     /**
-     * @brief The intrinsic velocity of the object. It will always try to move with the intrinsic velocity.
+     * @brief The base velocity of the object. It will always try to move with the base velocity.
      */
-    sf::Vector2f intrinsic_velocity = {0, 0};
+    sf::Vector2f base_velocity = {0, 0};
 
     /**
      * @brief The velocity imparted by the surface the object is resting on (if any) or if the object is a player
      * climbing another object.
      */
     sf::Vector2f friction_velocity = {0, 0};
-
-    /**
-     * @brief The velocity imparted by impulse resolution.
-     */
-    sf::Vector2f impulse_velocity = {0, 0};
-
-    /**
-     * @brief Sets the \code gravity_velocity\endcode to the given velocity and clamps it by \code MAX_FALL\endcode.
-     * @param velocity The new gravity velocity of the object.
-     */
-    void setGravityVelocity(sf::Vector2f velocity);
-
-    /**
-     * @brief Adds the given velocity to the object's \code gravity_velocity\endcode and clamps it by \code MAX_FALL\endcode.
-     * @param velocity The velocity to be added to the \code gravity_velocity\endcode.
-     */
-    void addGravityVelocity(sf::Vector2f velocity);
-
-    const sf::Vector2f& getGravityVelocity() const {
-        return gravity_velocity;
-    }
 
     /**
      * @brief Returns the total velocity of the PhysicsObject. This is the object's true overall velocity.

--- a/src/entity/PhysicsObject.cpp
+++ b/src/entity/PhysicsObject.cpp
@@ -14,18 +14,6 @@ const sf::Vector2f &PhysicsObject::getPositionRef() const {
     return position;
 }
 
-void PhysicsObject::setGravityVelocity(sf::Vector2f velocity) {
-    assert(velocity.x == 0);
-    gravity_velocity = velocity;
-    gravity_velocity.y = std::min(gravity_velocity.y, MAX_FALL);
-}
-
-void PhysicsObject::addGravityVelocity(sf::Vector2f velocity) {
-    assert(velocity.x == 0);
-    gravity_velocity += velocity;
-    gravity_velocity.y = std::min(gravity_velocity.y, MAX_FALL);
-}
-
 const sf::Sprite& PhysicsObject::getSprite() const {
     return sprite;
 }
@@ -45,13 +33,12 @@ void PhysicsObject::addPosition(sf::Vector2f position) {
 }
 
 sf::Vector2f PhysicsObject::getTotalVelocity() const {
-    return intrinsic_velocity + friction_velocity + impulse_velocity + gravity_velocity;
+    return base_velocity + friction_velocity;
 }
 
 void PhysicsObject::printVelocity(const std::string &name) const {
-    std::cout << name << " intrinsic_velocity: x = " << intrinsic_velocity.x << ", y = " << intrinsic_velocity.y << std::endl;
+    std::cout << name << " base_velocity: x = " << base_velocity.x << ", y = " << base_velocity.y << std::endl;
     std::cout << name << " friction_velocity: x = " << friction_velocity.x << ", y = " << friction_velocity.y << std::endl;
-    std::cout << name << " impulse_velocity: x = " << impulse_velocity.x << ", y = " << impulse_velocity.y << std::endl;
 }
 
 void PhysicsObject::printVelocity() const {

--- a/src/entity/player/PlayerInputHandler.cpp
+++ b/src/entity/player/PlayerInputHandler.cpp
@@ -29,18 +29,18 @@ void PlayerInputHandler::handleLeftRightMovement(float deltaTime) {
         // Move left
         moveSomewhere = true;
         player.facing = Facing::Left;
-        approach(player.intrinsic_velocity.x, -Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime * multiplier);
+        approach(player.base_velocity.x, -Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime * multiplier);
     }
 
     if (isPressed(moveRight) && (!isPressed(moveLeft) || wasPressedEarlierThan(moveLeft, moveRight))) {
         // Move right
         moveSomewhere = true;
         player.facing = Facing::Right;
-        approach(player.intrinsic_velocity.x, Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime * multiplier);
+        approach(player.base_velocity.x, Player::WALK_SPEED, Player::RUN_ACCELERATION * deltaTime * multiplier);
     }
 
     if (!moveSomewhere) {
-        approach(player.intrinsic_velocity.x, 0, Player::RUN_ACCELERATION * deltaTime * multiplier);
+        approach(player.base_velocity.x, 0, Player::RUN_ACCELERATION * deltaTime * multiplier);
     }
 }
 

--- a/src/physics/CollisionsHandler.cpp
+++ b/src/physics/CollisionsHandler.cpp
@@ -49,10 +49,6 @@ void CollisionsHandler::removeObject(CollidableObject& body) {
 
 void CollisionsHandler::update(float deltaTime) {
 
-    for (const auto& body: bodies) {
-        body.get().impulse_velocity *= 0.0f;
-    }
-
     std::unordered_set<CollidableObject*> friction_set_bodies;
 
     for (int i = 0; i < 8; i++) {
@@ -105,8 +101,8 @@ void CollisionsHandler::update(float deltaTime) {
                 }
             }
 
-            objectA->impulse_velocity += impulse * objectA->getInvMass();
-            objectB->impulse_velocity -= impulse * objectB->getInvMass();
+            objectA->base_velocity += impulse * objectA->getInvMass();
+            objectB->base_velocity -= impulse * objectB->getInvMass();
 
             float invMassSum = objectA->getInvMass() + objectB->getInvMass();
             float percent = 0.2;
@@ -190,7 +186,7 @@ void CollisionsHandler::moveImmovables(float deltaTime) const {
 
     if (collisions.empty()) {
         for (auto body: immovables) {
-            body.get().addGravityVelocity(body.get().gravity_acceleration * deltaTime);
+            body.get().base_velocity += body.get().gravity_acceleration * deltaTime;
             body.get().addPosition(body.get().getTotalVelocity() * deltaTime);
         }
         return;
@@ -205,16 +201,14 @@ void CollisionsHandler::moveImmovables(float deltaTime) const {
     // Move all objects to earliest_collision.collisionTime
 
     for (auto body: immovables) {
-        body.get().addGravityVelocity(body.get().gravity_acceleration * earliest_collision.collisionTime);
+        body.get().base_velocity += body.get().gravity_acceleration * earliest_collision.collisionTime;
         body.get().addPosition(body.get().getTotalVelocity() * earliest_collision.collisionTime);
     }
 
-    earliest_collision.objectA.intrinsic_velocity = {0, 0};
-    earliest_collision.objectA.impulse_velocity = {0, 0};
+    earliest_collision.objectA.base_velocity = {0, 0};
     earliest_collision.objectA.friction_velocity = {0, 0};
     earliest_collision.objectA.gravity_acceleration = {0, 0};
-    earliest_collision.objectB.intrinsic_velocity = {0, 0};
-    earliest_collision.objectB.impulse_velocity = {0, 0};
+    earliest_collision.objectB.base_velocity = {0, 0};
     earliest_collision.objectB.friction_velocity = {0, 0};
     earliest_collision.objectB.gravity_acceleration = {0, 0};
 
@@ -224,7 +218,7 @@ void CollisionsHandler::moveImmovables(float deltaTime) const {
 void CollisionsHandler::moveMovables(float deltaTime) const {
     for (auto body: bodies) {
         if (body.get().type == CollidableObjectType::Movable) {
-            body.get().addGravityVelocity(body.get().gravity_acceleration * deltaTime);
+            body.get().base_velocity += body.get().gravity_acceleration * deltaTime;
             body.get().addPosition(body.get().getTotalVelocity() * deltaTime);
         }
     }

--- a/src/physics/ContactResolution.cpp
+++ b/src/physics/ContactResolution.cpp
@@ -10,9 +10,9 @@ void ContactResolution::resolve(Collision collision) {
     CollidableObject& object = (collision.objectA.type == CollidableObjectType::Movable) ? collision.objectA : collision.objectB;
 
     if (collision.axis == CollisionAxis::Down || collision.axis == CollisionAxis::Up) {
-        object.intrinsic_velocity.y = 0;
+        object.base_velocity.y = 0;
     } else {
 
-        object.intrinsic_velocity.x = 0;
+        object.base_velocity.x = 0;
     }
 }


### PR DESCRIPTION
Redesigned velocity system. Instead of separate intrinsic, gravitational and impulse velocities, there is now a single base velocity. Reasons why each of these were created and why they are no longer needed:
1. Impulse velocity: I didn't want impulses to persist after they are no longer being imparted. It is difficult to get rid of just the impulse whilst not affecting player's intention of moving left/right or dashes. But I see now that a better solution is to let it be part of the "overall" velocity but the player always's x velocity always deaccelerates rapidly when they are not trying to move.
2. Gravitational velocity: I wanted to have a way to kind of reset the gravitational velocity part only when I wanted to, if the player decided to dash mid-air for example. But this comes with some issues. For example, when a player is resting on a platform, the impulse from the ground will oppose the gravity but if the gravitational velocity is not capped, these two will keep increasing to infinity. Even with the velocity capped, the player's "ground" status was unstable and flickering. Now I have a robust system of abilities where I can enable and disable velocities whenever I want.

Why friction velocity is staying: One aspect of the fake physics of a platformer makes it a necessity to have a separate friction velocity. If a player is on a moving platform, but the platform stops, then the player must also stop moving. The "friction velocity" should be exactly equal to the platform's current velocity. More importantly, free movement of a player relative to the platform its on forces us to add a friction velocity as a wrapper over the base velocity.