### PR TITLE
Add GitHub Actions CI to build all targets on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: brew install glfw ninja
+
+      - name: Cache CMake FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt') }}
+
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build all targets
+        run: cmake --build build --parallel


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`, running on every push and pull request
- Builds all four CMake targets on `macos-latest`: `2d-platformer`, `2d-platformer-sanitized`, `2d-platformer-tsan`, `game_lib`
- Caches the CMake `FetchContent` deps directory (SFML, nlohmann_json, glm) so repeat runs don't rebuild SFML from source every time

Fixes #25

## Test plan
- [ ] Confirm the workflow run succeeds on this PR